### PR TITLE
価格推移グラフ表示アプリの追加

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,12 +1,24 @@
-﻿<Window x:Class="analysCAR.MainWindow"
+<Window x:Class="analysCAR.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:analysCAR"
+        xmlns:oxy="http://oxyplot.org/wpf"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
+        Title="価格推移表示" Height="450" Width="800">
+    <Grid AllowDrop="True" Drop="Grid_Drop" DragOver="Grid_DragOver">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
+        <StackPanel Orientation="Horizontal" Margin="10">
+            <Button Content="フォルダを選択" Click="SelectFolder_Click" />
+            <TextBlock Margin="10,0,0,0" VerticalAlignment="Center" Text="フォルダをドラッグ＆ドロップしても読み込めます" />
+        </StackPanel>
+
+        <oxy:PlotView x:Name="plotView" Grid.Row="1" />
     </Grid>
 </Window>
+

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,18 +1,18 @@
-﻿using System.Text;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+using WinForms = System.Windows.Forms;
 
 namespace analysCAR
 {
     /// <summary>
-    /// Interaction logic for MainWindow.xaml
+    /// 価格の推移を表示するメインウィンドウ
     /// </summary>
     public partial class MainWindow : Window
     {
@@ -20,5 +20,102 @@ namespace analysCAR
         {
             InitializeComponent();
         }
+
+        private void SelectFolder_Click(object sender, RoutedEventArgs e)
+        {
+            using var dialog = new WinForms.FolderBrowserDialog
+            {
+                Description = "データフォルダを選択してください"
+            };
+            if (dialog.ShowDialog() == WinForms.DialogResult.OK)
+            {
+                LoadDataFromDirectory(dialog.SelectedPath);
+            }
+        }
+
+        private void Grid_DragOver(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                var paths = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (paths.Length > 0 && Directory.Exists(paths[0]))
+                {
+                    e.Effects = DragDropEffects.Copy;
+                }
+                else
+                {
+                    e.Effects = DragDropEffects.None;
+                }
+            }
+            else
+            {
+                e.Effects = DragDropEffects.None;
+            }
+            e.Handled = true;
+        }
+
+        private void Grid_Drop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                var paths = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (paths.Length > 0 && Directory.Exists(paths[0]))
+                {
+                    LoadDataFromDirectory(paths[0]);
+                }
+            }
+        }
+
+        private void LoadDataFromDirectory(string dir)
+        {
+            try
+            {
+                var points = new List<DataPoint>();
+                foreach (var dateDir in Directory.GetDirectories(dir))
+                {
+                    var csv = Directory.GetFiles(dateDir, "*.csv").FirstOrDefault();
+                    if (csv == null) continue;
+
+                    var prices = new List<double>();
+                    foreach (var line in File.ReadLines(csv).Skip(1))
+                    {
+                        var cols = line.Split(',');
+                        if (cols.Length > 3)
+                        {
+                            var priceStr = cols[3]
+                                .Replace("万円", string.Empty)
+                                .Replace(",", string.Empty)
+                                .Trim();
+                            if (double.TryParse(priceStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var price))
+                            {
+                                prices.Add(price);
+                            }
+                        }
+                    }
+
+                    if (prices.Count > 0 &&
+                        DateTime.TryParseExact(Path.GetFileName(dateDir), "yyyy年MM月dd日", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+                    {
+                        points.Add(new DataPoint(DateTimeAxis.ToDouble(dt), prices.Average()));
+                    }
+                }
+
+                points = points.OrderBy(p => p.X).ToList();
+
+                var model = new PlotModel { Title = "平均支払総額の推移（万円）" };
+                model.Axes.Add(new DateTimeAxis { Position = AxisPosition.Bottom, StringFormat = "yyyy/MM/dd", Title = "日付" });
+                model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "価格（万円）" });
+                var series = new LineSeries { MarkerType = MarkerType.Circle };
+                series.Points.AddRange(points);
+                model.Series.Add(series);
+
+                plotView.Model = model;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"読み込み中にエラーが発生しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
     }
 }
+

--- a/analysCAR.csproj
+++ b/analysCAR.csproj
@@ -6,6 +6,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## 概要
- データフォルダをドラッグ＆ドロップまたは選択して読み込み
- OxyPlot を用いた平均支払総額の時系列グラフ描画

## テスト
- `dotnet restore` (コマンド未インストールのため失敗)
- `apt-get update` (403 Forbidden により必要パッケージを取得できず)


------
https://chatgpt.com/codex/tasks/task_e_68a17db971e08321b39564a615882e76