### PR TITLE
feat: allow selecting car model and show daily prices

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -15,6 +15,7 @@
 
         <StackPanel Orientation="Horizontal" Margin="10">
             <Button Content="フォルダを選択" Click="SelectFolder_Click" />
+            <ComboBox x:Name="carModelCombo" Width="150" Margin="10,0,0,0" SelectionChanged="CarModelCombo_SelectionChanged" />
             <TextBlock Margin="10,0,0,0" VerticalAlignment="Center" Text="フォルダをドラッグ＆ドロップしても読み込めます" />
         </StackPanel>
 


### PR DESCRIPTION
## Summary
- allow choosing a car model via a new dropdown and load its data
- compute and display daily average prices for the selected model
- correct y-axis label wording

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1816a81148321b1e4bf3db74eec4f